### PR TITLE
feat(backend): implement profile settings endpoints

### DIFF
--- a/apps/authentication-service/src/controller/delete.user.controller.ts
+++ b/apps/authentication-service/src/controller/delete.user.controller.ts
@@ -1,0 +1,70 @@
+import {
+  authApiRoutes,
+  REFRESH_TOKEN_COOKIE_NAME,
+} from "@lasl/app-contracts/api/auth";
+import { USER_ERRORS } from "@lasl/app-contracts/errors/user";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { StatusCodes } from "http-status-codes";
+import { SessionModel } from "@/src/model/session.model.ts";
+import { UserModel } from "@/src/model/user.model.ts";
+import type { DeleteUserInputSchemaType } from "@/src/schema/delete.user.schema.ts";
+
+const fullRefreshSessionRoute = authApiRoutes.session.refresh();
+
+export const deleteUserHandler = async (
+  req: FastifyRequest<{
+    // biome-ignore lint/style/useNamingConvention: property name comes from fastify
+    Body: DeleteUserInputSchemaType["body"];
+  }>,
+  reply: FastifyReply,
+) => {
+  const { userId, sessionId } = req;
+  const { password } = req.body;
+
+  if (!(userId && sessionId)) {
+    return reply.status(StatusCodes.UNAUTHORIZED).send({
+      message: "User not authenticated",
+    });
+  }
+
+  try {
+    const userDoc = await UserModel.findById(userId);
+
+    if (!userDoc) {
+      return reply.status(StatusCodes.NOT_FOUND).send({
+        message: "User not found",
+      });
+    }
+
+    const isPasswordValid = await userDoc.validatePassword(password);
+    if (!isPasswordValid) {
+      return reply.status(StatusCodes.FORBIDDEN).send({
+        message: USER_ERRORS.passwordIncorrect,
+      });
+    }
+
+    // Invalidate session
+    const session = await SessionModel.findById(sessionId);
+    if (session) {
+      session.valid = false;
+      await session.save();
+    }
+
+    // Delete user
+    await UserModel.deleteOne({ _id: userId });
+
+    // Clear refresh token cookie
+    reply.clearCookie(REFRESH_TOKEN_COOKIE_NAME, {
+      path: fullRefreshSessionRoute,
+    });
+
+    return reply.status(StatusCodes.OK).send({
+      message: "Account deleted successfully",
+    });
+  } catch (error) {
+    req.log.error(error, `An error occurred deleting user: ${userId}`);
+    return reply.status(StatusCodes.BAD_REQUEST).send({
+      message: "Failed to delete account",
+    });
+  }
+};

--- a/apps/authentication-service/src/controller/update.password.controller.ts
+++ b/apps/authentication-service/src/controller/update.password.controller.ts
@@ -1,0 +1,55 @@
+import { USER_ERRORS } from "@lasl/app-contracts/errors/user";
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { StatusCodes } from "http-status-codes";
+import { UserModel } from "@/src/model/user.model.ts";
+import type { UpdatePasswordInputSchemaType } from "@/src/schema/update.password.schema.ts";
+
+export const updatePasswordHandler = async (
+  req: FastifyRequest<{
+    // biome-ignore lint/style/useNamingConvention: property name comes from fastify
+    Body: UpdatePasswordInputSchemaType["body"];
+  }>,
+  reply: FastifyReply,
+) => {
+  const { userId } = req;
+  const { currentPassword, password } = req.body;
+
+  if (!userId) {
+    return reply.status(StatusCodes.UNAUTHORIZED).send({
+      message: "User not authenticated",
+    });
+  }
+
+  try {
+    const userDoc = await UserModel.findById(userId);
+
+    if (!userDoc) {
+      return reply.status(StatusCodes.NOT_FOUND).send({
+        message: "User not found",
+      });
+    }
+
+    const isCurrentPasswordValid =
+      await userDoc.validatePassword(currentPassword);
+    if (!isCurrentPasswordValid) {
+      return reply.status(StatusCodes.FORBIDDEN).send({
+        message: USER_ERRORS.passwordIncorrect,
+      });
+    }
+
+    userDoc.password = password;
+    await userDoc.save();
+
+    return reply.status(StatusCodes.OK).send({
+      message: "Password changed successfully",
+    });
+  } catch (error) {
+    req.log.error(
+      error,
+      `An error occurred updating password for user: ${userId}`,
+    );
+    return reply.status(StatusCodes.BAD_REQUEST).send({
+      message: "Failed to update password",
+    });
+  }
+};

--- a/apps/authentication-service/src/routes/user.routes.schema.ts
+++ b/apps/authentication-service/src/routes/user.routes.schema.ts
@@ -147,3 +147,37 @@ export const updateCurrentAuthenticatedUserForbiddenResponseSchema =
 export type UpdateCurrentAuthenticatedUserForbiddenResponse = z.infer<
   typeof updateCurrentAuthenticatedUserForbiddenResponseSchema
 >;
+
+// Update Password Response
+export const updatePasswordSuccessResponseSchema = genericMessageResponseSchema;
+export type UpdatePasswordSuccessResponse = z.infer<
+  typeof updatePasswordSuccessResponseSchema
+>;
+
+export const updatePasswordBadRequestResponseSchema =
+  genericMessageResponseSchema;
+export type UpdatePasswordBadRequestResponse = z.infer<
+  typeof updatePasswordBadRequestResponseSchema
+>;
+
+export const updatePasswordForbiddenResponseSchema =
+  genericMessageResponseSchema;
+export type UpdatePasswordForbiddenResponse = z.infer<
+  typeof updatePasswordForbiddenResponseSchema
+>;
+
+// Delete User Response
+export const deleteUserSuccessResponseSchema = genericMessageResponseSchema;
+export type DeleteUserSuccessResponse = z.infer<
+  typeof deleteUserSuccessResponseSchema
+>;
+
+export const deleteUserBadRequestResponseSchema = genericMessageResponseSchema;
+export type DeleteUserBadRequestResponse = z.infer<
+  typeof deleteUserBadRequestResponseSchema
+>;
+
+export const deleteUserForbiddenResponseSchema = genericMessageResponseSchema;
+export type DeleteUserForbiddenResponse = z.infer<
+  typeof deleteUserForbiddenResponseSchema
+>;

--- a/apps/authentication-service/src/routes/user.routes.ts
+++ b/apps/authentication-service/src/routes/user.routes.ts
@@ -5,7 +5,9 @@ import {
 import type { FastifyInstance } from "fastify";
 import { StatusCodes } from "http-status-codes";
 import { z } from "zod";
+import { deleteUserHandler } from "@/src/controller/delete.user.controller.ts";
 import { resendVerificationMailHandler } from "@/src/controller/resend.verification.mail.controller.ts";
+import { updatePasswordHandler } from "@/src/controller/update.password.controller.ts";
 import { updateUserHandler } from "@/src/controller/update.user.controller.ts";
 import {
   createUserBadRequestResponseSchema,
@@ -13,6 +15,9 @@ import {
   createUserInternalServerErrorResponseSchema,
   createUserSuccessResponseSchema,
   createUserUnprocessableEntityResponseSchema,
+  deleteUserBadRequestResponseSchema,
+  deleteUserForbiddenResponseSchema,
+  deleteUserSuccessResponseSchema,
   forgotPasswordSuccessResponseSchema,
   getCurrentAuthenticatedUserForbiddenResponseSchema,
   getCurrentAuthenticatedUserSuccessResponseSchema,
@@ -24,6 +29,9 @@ import {
   updateCurrentAuthenticatedUserBadRequestResponseSchema,
   updateCurrentAuthenticatedUserForbiddenResponseSchema,
   updateCurrentAuthenticatedUserSuccessResponseSchema,
+  updatePasswordBadRequestResponseSchema,
+  updatePasswordForbiddenResponseSchema,
+  updatePasswordSuccessResponseSchema,
   verifyUserBadRequestResponseSchema,
   verifyUserConflictResponseSchema,
   verifyUserInternalServerErrorResponseSchema,
@@ -36,6 +44,14 @@ import { getUserHandler } from "../controller/get.user.controller.ts";
 import { resetPasswordHandler } from "../controller/reset.password.controller.ts";
 import { verifyUserHandler } from "../controller/verify.user.controller.ts";
 import { deserializeUser } from "../middleware/authentication.hook.ts";
+import {
+  type DeleteUserInputSchemaType,
+  deleteUserInputJsonSchema,
+} from "../schema/delete.user.schema.ts";
+import {
+  type UpdatePasswordInputSchemaType,
+  updatePasswordInputJsonSchema,
+} from "../schema/update.password.schema.ts";
 import {
   createUserInputJsonSchema,
   forgotPasswordInputJsonSchema,
@@ -229,5 +245,67 @@ export const userRoutes = (fastifyInstance: FastifyInstance) => {
       },
     },
     updateUserHandler,
+  );
+
+  fastifyInstance.post(
+    authApiRoutes.user.updatePassword(),
+    {
+      preHandler: deserializeUser<{
+        // biome-ignore lint/style/useNamingConvention: property name comes from fastify
+        Body: UpdatePasswordInputSchemaType["body"];
+      }>,
+      schema: {
+        summary: "Update the user's password",
+        tags: [UserSwaggerTag],
+        description: `Send the authorization header in ${AUTHENTICATION_TYPE} format along with the current password and the new password`,
+        headers: {
+          type: "object",
+          properties: { authorization: { type: "string" } },
+          required: ["authorization"],
+        },
+        body: updatePasswordInputJsonSchema,
+        response: {
+          [StatusCodes.OK]: z.toJSONSchema(updatePasswordSuccessResponseSchema),
+          [StatusCodes.BAD_REQUEST]: z.toJSONSchema(
+            updatePasswordBadRequestResponseSchema,
+          ),
+          [StatusCodes.FORBIDDEN]: z.toJSONSchema(
+            updatePasswordForbiddenResponseSchema,
+          ),
+        },
+      },
+    },
+    updatePasswordHandler,
+  );
+
+  fastifyInstance.delete(
+    authApiRoutes.user.delete(),
+    {
+      preHandler: deserializeUser<{
+        // biome-ignore lint/style/useNamingConvention: property name comes from fastify
+        Body: DeleteUserInputSchemaType["body"];
+      }>,
+      schema: {
+        summary: "Delete the current authenticated user account",
+        tags: [UserSwaggerTag],
+        description: `Send the authorization header in ${AUTHENTICATION_TYPE} format along with the current password to delete the account permanently`,
+        headers: {
+          type: "object",
+          properties: { authorization: { type: "string" } },
+          required: ["authorization"],
+        },
+        body: deleteUserInputJsonSchema,
+        response: {
+          [StatusCodes.OK]: z.toJSONSchema(deleteUserSuccessResponseSchema),
+          [StatusCodes.BAD_REQUEST]: z.toJSONSchema(
+            deleteUserBadRequestResponseSchema,
+          ),
+          [StatusCodes.FORBIDDEN]: z.toJSONSchema(
+            deleteUserForbiddenResponseSchema,
+          ),
+        },
+      },
+    },
+    deleteUserHandler,
   );
 };

--- a/apps/authentication-service/src/schema/delete.user.schema.ts
+++ b/apps/authentication-service/src/schema/delete.user.schema.ts
@@ -1,0 +1,15 @@
+import { deleteUserSchema } from "@lasl/app-contracts/schemas/user";
+import { z } from "zod";
+
+const ZOD_JSON_SCHEMA_TARGET = "draft-7";
+
+export const deleteUserInputSchema = z.object({
+  body: deleteUserSchema,
+});
+
+export const deleteUserInputJsonSchema = z.toJSONSchema(
+  deleteUserInputSchema.shape.body,
+  { target: ZOD_JSON_SCHEMA_TARGET },
+);
+
+export type DeleteUserInputSchemaType = z.infer<typeof deleteUserInputSchema>;

--- a/apps/authentication-service/src/schema/update.password.schema.ts
+++ b/apps/authentication-service/src/schema/update.password.schema.ts
@@ -1,0 +1,17 @@
+import { updatePasswordSchema } from "@lasl/app-contracts/schemas/user";
+import { z } from "zod";
+
+const ZOD_JSON_SCHEMA_TARGET = "draft-7";
+
+export const updatePasswordInputSchema = z.object({
+  body: updatePasswordSchema,
+});
+
+export const updatePasswordInputJsonSchema = z.toJSONSchema(
+  updatePasswordInputSchema.shape.body,
+  { target: ZOD_JSON_SCHEMA_TARGET },
+);
+
+export type UpdatePasswordInputSchemaType = z.infer<
+  typeof updatePasswordInputSchema
+>;

--- a/apps/authentication-service/src/schema/user.schema.ts
+++ b/apps/authentication-service/src/schema/user.schema.ts
@@ -1,7 +1,6 @@
 import { SUPPORTED_LOCALES } from "@lasl/app-contracts/locales";
 import {
   createUserSchema,
-  createUserSchemaBase,
   passwordMatchRefinement,
   resetPasswordParamsSchema,
   userEmailSchema,
@@ -11,22 +10,24 @@ import { z } from "zod";
 
 const ZOD_JSON_SCHEMA_TARGET = "draft-7";
 
+const MIN_NAME_LENGTH = 2;
+const MAX_NAME_LENGTH = 50;
+
 export const createUserInputSchema = z.object({
   body: createUserSchema,
 });
 export const updateUserInputSchema = z.object({
-  body: createUserSchemaBase
-    .pick({ firstName: true, lastName: true })
-    .partial()
-    .extend({
-      settings: z
-        .strictObject({
-          darkMode: z.boolean().optional(),
-          uiLanguage: z.enum(SUPPORTED_LOCALES).optional(),
-          contentLanguage: z.enum(SUPPORTED_LOCALES).optional(),
-        })
-        .optional(),
-    }),
+  body: z.object({
+    firstName: z.string().min(MIN_NAME_LENGTH).max(MAX_NAME_LENGTH).optional(),
+    lastName: z.string().min(MIN_NAME_LENGTH).max(MAX_NAME_LENGTH).optional(),
+    settings: z
+      .strictObject({
+        darkMode: z.boolean().optional(),
+        uiLanguage: z.enum(SUPPORTED_LOCALES).optional(),
+        contentLanguage: z.enum(SUPPORTED_LOCALES).optional(),
+      })
+      .optional(),
+  }),
 });
 export const verifyUserInputSchema = z.object({
   params: z.object({

--- a/apps/authentication-service/test/controller/delete.user.controller.test.ts
+++ b/apps/authentication-service/test/controller/delete.user.controller.test.ts
@@ -1,0 +1,144 @@
+import { REFRESH_TOKEN_COOKIE_NAME } from "@lasl/app-contracts/api/auth";
+import { USER_ERRORS } from "@lasl/app-contracts/errors/user";
+import {
+  setupFastifyTestEnvironment,
+  teardownFastifyTestEnvironment,
+} from "@lasl/test-utils-fastify/setup-utils";
+import { StatusCodes } from "http-status-codes";
+import mongoose from "mongoose";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { buildApp } from "@/src/app.ts";
+import { deleteUserHandler } from "@/src/controller/delete.user.controller.ts";
+import { SessionModel } from "@/src/model/session.model.ts";
+import { UserModel } from "@/src/model/user.model.ts";
+import { mockUserDataWithSettings } from "@/test/__mocks__/user.mock.ts";
+
+describe("delete user controller", () => {
+  beforeAll(async () => {
+    await setupFastifyTestEnvironment({ buildApp, useMongo: true });
+  });
+
+  afterAll(async () => {
+    await teardownFastifyTestEnvironment();
+  });
+
+  afterEach(async () => {
+    await UserModel.deleteMany();
+    await SessionModel.deleteMany();
+  });
+
+  it("should respond with 401 if there is no current authenticated user", async () => {
+    const req = {
+      body: {
+        password: "securePassword123",
+      },
+    };
+    const reply = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+    };
+
+    // @ts-expect-error ok in test
+    await deleteUserHandler(req, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(StatusCodes.UNAUTHORIZED);
+    expect(reply.send).toHaveBeenCalledWith({
+      message: "User not authenticated",
+    });
+  });
+
+  it("should respond with 404 if user cannot be found in database", async () => {
+    const secondId = new mongoose.Types.ObjectId().toString();
+    const req = {
+      userId: secondId,
+      sessionId: new mongoose.Types.ObjectId().toString(),
+      body: {
+        password: "securePassword123",
+      },
+      log: { error: vi.fn() },
+    };
+    const reply = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+    };
+
+    // @ts-expect-error ok in test
+    await deleteUserHandler(req, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND);
+    expect(reply.send).toHaveBeenCalledWith({
+      message: "User not found",
+    });
+  });
+
+  it("should respond with 403 if password is wrong", async () => {
+    const user = await UserModel.create(mockUserDataWithSettings);
+    const session = await SessionModel.create({ user: user._id });
+    const req = {
+      userId: user._id.toString(),
+      sessionId: session._id.toString(),
+      body: {
+        password: "wrongPassword",
+      },
+      log: { error: vi.fn() },
+    };
+    const reply = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+    };
+
+    // @ts-expect-error ok in test
+    await deleteUserHandler(req, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(StatusCodes.FORBIDDEN);
+    expect(reply.send).toHaveBeenCalledWith({
+      message: USER_ERRORS.passwordIncorrect,
+    });
+  });
+
+  it("should respond with 200, delete user, invalidate session, and clear cookie on success", async () => {
+    const user = await UserModel.create(mockUserDataWithSettings);
+    const session = await SessionModel.create({ user: user._id });
+
+    const req = {
+      userId: user._id.toString(),
+      sessionId: session._id.toString(),
+      body: {
+        password: "securePassword123",
+      },
+      log: { error: vi.fn() },
+    };
+    const reply = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+      clearCookie: vi.fn().mockReturnThis(),
+    };
+
+    // @ts-expect-error ok in test
+    await deleteUserHandler(req, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(StatusCodes.OK);
+    expect(reply.send).toHaveBeenCalledWith({
+      message: "Account deleted successfully",
+    });
+
+    const deletedUser = await UserModel.findById(user._id);
+    expect(deletedUser).toBeNull();
+
+    const invalidatedSession = await SessionModel.findById(session._id);
+    expect(invalidatedSession?.valid).toBe(false);
+
+    expect(reply.clearCookie).toHaveBeenCalledWith(
+      REFRESH_TOKEN_COOKIE_NAME,
+      expect.any(Object),
+    );
+  });
+});

--- a/apps/authentication-service/test/controller/update.password.controller.test.ts
+++ b/apps/authentication-service/test/controller/update.password.controller.test.ts
@@ -1,0 +1,135 @@
+import { USER_ERRORS } from "@lasl/app-contracts/errors/user";
+import {
+  setupFastifyTestEnvironment,
+  teardownFastifyTestEnvironment,
+} from "@lasl/test-utils-fastify/setup-utils";
+import { StatusCodes } from "http-status-codes";
+import mongoose from "mongoose";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { buildApp } from "@/src/app.ts";
+import { updatePasswordHandler } from "@/src/controller/update.password.controller.ts";
+import { UserModel } from "@/src/model/user.model.ts";
+import { mockUserDataWithSettings } from "@/test/__mocks__/user.mock.ts";
+
+describe("update password controller", () => {
+  beforeAll(async () => {
+    await setupFastifyTestEnvironment({ buildApp, useMongo: true });
+  });
+
+  afterAll(async () => {
+    await teardownFastifyTestEnvironment();
+  });
+
+  afterEach(async () => {
+    await UserModel.deleteMany();
+  });
+
+  it("should respond with 401 if there is no current authenticated user", async () => {
+    const req = {
+      body: {
+        currentPassword: "securePassword123",
+        password: "NewSecurePassword123",
+        passwordConfirmation: "NewSecurePassword123",
+      },
+    };
+    const reply = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+    };
+
+    // @ts-expect-error ok in test
+    await updatePasswordHandler(req, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(StatusCodes.UNAUTHORIZED);
+    expect(reply.send).toHaveBeenCalledWith({
+      message: "User not authenticated",
+    });
+  });
+
+  it("should respond with 404 if user cannot be found in database", async () => {
+    const secondId = new mongoose.Types.ObjectId().toString();
+    const req = {
+      userId: secondId,
+      body: {
+        currentPassword: "securePassword123",
+        password: "NewSecurePassword123",
+        passwordConfirmation: "NewSecurePassword123",
+      },
+      log: { error: vi.fn() },
+    };
+    const reply = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+    };
+
+    // @ts-expect-error ok in test
+    await updatePasswordHandler(req, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND);
+    expect(reply.send).toHaveBeenCalledWith({
+      message: "User not found",
+    });
+  });
+
+  it("should respond with 403 if current password is wrong", async () => {
+    const user = await UserModel.create(mockUserDataWithSettings);
+    const req = {
+      userId: user._id.toString(),
+      body: {
+        currentPassword: "wrongPassword",
+        password: "NewSecurePassword123",
+        passwordConfirmation: "NewSecurePassword123",
+      },
+      log: { error: vi.fn() },
+    };
+    const reply = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+    };
+
+    // @ts-expect-error ok in test
+    await updatePasswordHandler(req, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(StatusCodes.FORBIDDEN);
+    expect(reply.send).toHaveBeenCalledWith({
+      message: USER_ERRORS.passwordIncorrect,
+    });
+  });
+
+  it("should respond with 200 if password was successfully updated", async () => {
+    const user = await UserModel.create(mockUserDataWithSettings);
+    const req = {
+      userId: user._id.toString(),
+      body: {
+        currentPassword: "securePassword123",
+        password: "NewSecurePassword123",
+        passwordConfirmation: "NewSecurePassword123",
+      },
+      log: { error: vi.fn() },
+    };
+    const reply = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn(),
+    };
+
+    // @ts-expect-error ok in test
+    await updatePasswordHandler(req, reply);
+
+    expect(reply.status).toHaveBeenCalledWith(StatusCodes.OK);
+    expect(reply.send).toHaveBeenCalledWith({
+      message: "Password changed successfully",
+    });
+
+    const updatedUser = await UserModel.findById(user._id);
+    const isValid = await updatedUser!.validatePassword("NewSecurePassword123");
+    expect(isValid).toBe(true);
+  });
+});

--- a/apps/frontend/src/shared/formErrors.ts
+++ b/apps/frontend/src/shared/formErrors.ts
@@ -17,4 +17,5 @@ export const userErrorMessages: Record<UserErrorKey, MessageDescriptor> = {
   [USER_ERRORS.passwordNumber]: msg`Password must contain at least one number`,
   [USER_ERRORS.passwordRequired]: msg`Password is required`,
   [USER_ERRORS.passwordUppercase]: msg`Password must contain at least one uppercase letter`,
+  [USER_ERRORS.passwordIncorrect]: msg`Incorrect password`,
 };

--- a/features/0001_profile-settings/05_backend-notes.md
+++ b/features/0001_profile-settings/05_backend-notes.md
@@ -1,0 +1,22 @@
+# Backend Notes: Profile Settings
+
+## What Was Implemented
+Added backend support for the profile settings feature.
+- **Controllers**: Added `update.password.controller.ts` for handling password changes, and `delete.user.controller.ts` for managing account deletion requests.
+- **Routes**: Registered `POST /api/v1/users/me/password` and `DELETE /api/v1/users/me` using the existing `authApiRoutes` structure.
+- **Schemas**: Extracted `updatePasswordSchema` and `deleteUserSchema` into Fastify JSON schemas in `update.password.schema.ts` and `delete.user.schema.ts`.
+- **Validation**: Added lengths constraints (min 2, max 50) for `firstName` and `lastName` on the `PATCH /api/v1/users/me` endpoint.
+- **Tests**: Created unit tests for the new `updatePassword` and `deleteUser` controllers.
+
+## New Endpoints
+| Method | Path | Auth required | Success status |
+|--------|------|---------------|---------------|
+| POST   | /api/v1/users/me/password | Yes (deserializeUser) | 200 |
+| DELETE | /api/v1/users/me          | Yes (deserializeUser) | 200 |
+
+## Deviations from Arch Design
+None — followed arch design exactly.
+
+## Notes for Frontend Engineer
+- The `PATCH /api/v1/users/me` endpoint now enforces `min(2).max(50)` lengths for `firstName` and `lastName`.
+- If `updatePassword` or `deleteAccount` is called with an invalid password, the backend returns a `403 Forbidden` response with a localized message using the `USER_ERRORS.passwordIncorrect` constant. Ensure this maps properly on the frontend form.


### PR DESCRIPTION
Implemented the backend requirements for the profile settings feature. This includes creating the update password and delete user controllers, adding corresponding route handlers with their request schemas mapped from `app-contracts`, implementing name length validation in the existing user update schema, and ensuring all tests are covered and passing. Created the sentinel notes file as requested.

---
*PR created automatically by Jules for task [18275904021725542573](https://jules.google.com/task/18275904021725542573) started by @Menahra*